### PR TITLE
Update deprecated use of `qr(..., Val{true})`

### DIFF
--- a/src/lputil.jl
+++ b/src/lputil.jl
@@ -216,7 +216,7 @@ function _preduce1!(n::Int, m::Int, p::Int, M::AbstractMatrix{T}, N::AbstractMat
       CE = view(M,ic,ja)
       EE = view(N,ic,coff+npm+1:nM)
       if fast
-         QR = qr!(D, Val(true))
+         QR = qr!(D, ColumnNorm())
          τ = count(x -> x > tol, abs.(diag(QR.R))) 
       else
          τ = count(x -> x > tol, svdvals(D))

--- a/src/lputil.jl
+++ b/src/lputil.jl
@@ -220,7 +220,7 @@ function _preduce1!(n::Int, m::Int, p::Int, M::AbstractMatrix{T}, N::AbstractMat
          τ = count(x -> x > tol, abs.(diag(QR.R))) 
       else
          τ = count(x -> x > tol, svdvals(D))
-         QR = qr!(D, Val(true))
+         QR = qr!(D, ColumnNorm())
       end
       B[:,:] = B[:,QR.p]
       lmul!(QR.Q',CE)
@@ -328,12 +328,12 @@ function _preduce2!(n::Int, m::Int, p::Int, M::AbstractMatrix{T}, N::AbstractMat
       ic = roff+n+1:roff+npp
       D = view(M,ic,jb)
       if fast
-         QR = qr!(copy(D'), Val(true))
+         QR = qr!(copy(D'), ColumnNorm())
          τ = count(x -> x > tol, abs.(diag(QR.R))) 
       else
          # τ = rank(D; atol = tol)
          τ = count(x -> x > tol, svdvals(D))
-         QR = qr!(copy(D'), Val(true))
+         QR = qr!(copy(D'), ColumnNorm())
       end
       rmul!(BE,QR.Q)  # BE*Q
       jt = m:-1:1


### PR DESCRIPTION
If julia is started with `--depwarn=yes`, the following deprecation warning is issued
```
julia> gnugap(G, G)
┌ Warning: `qr!(A::AbstractMatrix, ::Val{true})` is deprecated, use `qr!(A, ColumnNorm())` instead.
```
This PR makes the suggested change