### PR TITLE
make sure eigvals are always complex

### DIFF
--- a/src/gsfstab.jl
+++ b/src/gsfstab.jl
@@ -1357,18 +1357,18 @@ function isqtriu(A)
    end
    return true
 end
-function eigvalsnosort(M; kwargs...)
+function eigvalsnosort(M; kwargs...)::Vector{Complex{real(eltype(M))}}
    return eigvals(M; sortby=nothing, kwargs...)
 end
-function eigvalsnosort(M, N; kwargs...)
+function eigvalsnosort(M, N; kwargs...)::Vector{Complex{real(eltype(M))}}
    ev = eigvals(M, N; sortby=nothing, kwargs...)
    eltype(M) <: Complex || (ev[imag.(ev) .> 0] = conj(ev[imag.(ev) .< 0]))
    return ev
 end
-function eigvalsnosort!(M; kwargs...)
+function eigvalsnosort!(M; kwargs...)::Vector{Complex{real(eltype(M))}}
    return eigvals!(M; sortby=nothing, kwargs...)
 end
-function eigvalsnosort!(M, N; kwargs...)
+function eigvalsnosort!(M, N; kwargs...)::Vector{Complex{real(eltype(M))}}
    ev = eigvals!(M, N; sortby=nothing, kwargs...)
    eltype(M) <: Complex || (ev[imag.(ev) .> 0] = conj(ev[imag.(ev) .< 0]))
    return ev


### PR DESCRIPTION
The fact that `eigvals` is type unstable, it can return both real or complex eigvals, appears to cause a lot of type inference problems in DescriptorSystems, leading to long compilation times. This change reduces the compilation time for `gnugap` by about 40 seconds.

Ref: https://github.com/andreasvarga/DescriptorSystems.jl/issues/9