### PR TITLE
use the correct liblapack name

### DIFF
--- a/src/lapackutil2.jl
+++ b/src/lapackutil2.jl
@@ -1,7 +1,7 @@
 module LapackUtil2
 
 #const liblapack = VERSION < v"1.7" ? Base.liblapack_name : "libblastrampoline" * (Sys.iswindows() ? "-5" : "")
-const liblapack = Base.liblapack_name
+import LinearAlgebra.LAPACK.liblapack
 
 import LinearAlgebra.BLAS.@blasfunc
 


### PR DESCRIPTION
We got reports of users segfaulting when BLAS functions in this module was called. This was debugged down into an inconsistency between `Base.liblapack_name` and `LinearAlgebra.LAPACK.liblapack`. The correct one to use is the latter and with that change the segfaults disappeared. Also note that the former might be removed (https://github.com/JuliaLang/julia/pull/50699).

As a side note, some of the functions provided here are now available in LinearAlgebra itself, see for example https://github.com/JuliaLang/julia/pull/32390.